### PR TITLE
converted line endings to unix format

### DIFF
--- a/bin/goconfig
+++ b/bin/goconfig
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env node
 
 'use strict';


### PR DESCRIPTION
I have converted the line endings to UNIX type, in the "bin/goconfig" file to fix compatibility issues with Linux/mac systems
